### PR TITLE
Arccos distribution

### DIFF
--- a/src/distributions.jl
+++ b/src/distributions.jl
@@ -1,7 +1,18 @@
-export Degenerate
+export Degenerate, Arccos
 
 struct Degenerate{T<:Real} <: ContinuousUnivariateDistribution
     x::T
 end # struct
-
 Base.rand(d::Degenerate) = d.x
+
+struct Arccos{T<:Real} <: ContinuousUnivariateDistribution
+    a::T
+    b::T
+    Arccos{T}(a::T, b::T) where {T} = new{T}(a::T, b::T)
+end
+function Arccos(a::Real, b::Real; check_args::Bool=true)
+    Distributions.@check_args Arccos a<b -1≤a≤1 -1≤b≤1
+    return Arccos{Float64}(Float64(a), Float64(b))
+end # function
+Arccos() = Arccos(-1,1)
+Base.rand(rng::AbstractRNG, d::Arccos) = acos(rand(rng, Uniform(d.a, d.b)))

--- a/src/motility.jl
+++ b/src/motility.jl
@@ -36,20 +36,20 @@ abstract type AbstractMotilityTwoStep <: AbstractMotility end
 Base.@kwdef struct RunTumble <: AbstractMotilityOneStep
     speed = Degenerate(1.0)
     polar = Uniform(-π, π) # in-plane
-    azimuthal = Uniform(0,2π) # out-of-plane
+    azimuthal = Arccos(-1, 1) # out-of-plane
 end # struct
 
 Base.@kwdef struct RunReverse <: AbstractMotilityOneStep
     speed = Degenerate(1.0)
     polar = Degenerate(π)
-    azimuthal = Uniform(0,2π)
+    azimuthal = Arccos(-1, 1)
 end # strut 
 
 Base.@kwdef struct RunReverseFlick <: AbstractMotilityTwoStep
     speed = Degenerate(1.0)
     polar_0 = Degenerate(π)
-    azimuthal_0 = Uniform(0,2π)
+    azimuthal_0 = Arccos(-1, 1)
     polar_1 = Degenerate(π/2)
-    azimuthal_1 = Uniform(0,2π)
+    azimuthal_1 = Arccos(-1, 1)
     motile_state::Vector{Int} = rand(0:1, 1)
 end # struct 

--- a/src/motility.jl
+++ b/src/motility.jl
@@ -13,9 +13,9 @@ abstract type AbstractMotility end
 One-step motility patterns (such as run-tumble and run-reverse).
 Subtypes must have at least the following fields:
 - `speed`: distribution of microbe speed, new values extracted after each turn
-- `yaw`: distribution of in-plane reorientations
-- `pitch`: distribution of out-of-plane reorientations
-For 2-dimensional microbe types, only `yaw` defines reorientations.
+- `polar`: distribution of in-plane reorientations
+- `azimuthal`: distribution of out-of-plane reorientations
+For 2-dimensional microbe types, only `polar` defines reorientations.
 """
 abstract type AbstractMotilityOneStep <: AbstractMotility end
 
@@ -24,32 +24,32 @@ abstract type AbstractMotilityOneStep <: AbstractMotility end
 Two-step motility patterns (such as run-reverse-flick).
 Subtypes must have at least the following fields:
 - `speed`: distribution of microbe speed, new values extracted after each turn
-- `yaw_0`: distribution of in-plane reorientations for motile state 0
-- `pitch_0`: distribution of out-of-plane reorientations for motile state 0
-- `yaw_1`: distribution of in-plane reorientations for motile state 1
-- `pitch_1`: distribution of out-of-plane reorientations for motile state 1
+- `polar_0`: distribution of in-plane reorientations for motile state 0
+- `azimuthal_0`: distribution of out-of-plane reorientations for motile state 0
+- `polar_1`: distribution of in-plane reorientations for motile state 1
+- `azimuthal_1`: distribution of out-of-plane reorientations for motile state 1
 - `motile_state::Vector{Int}`: defines current motile state (`[0]` or `[1]`)
-For 2-dimensional microbe types, only `yaw_0` and `yaw_1` define reorientations.
+For 2-dimensional microbe types, only `polar_0` and `polar_1` define reorientations.
 """
 abstract type AbstractMotilityTwoStep <: AbstractMotility end
 
 Base.@kwdef struct RunTumble <: AbstractMotilityOneStep
     speed = Degenerate(1.0)
-    yaw = Uniform(-π, π) # in-plane
-    pitch = Uniform(0,2π) # out-of-plane
+    polar = Uniform(-π, π) # in-plane
+    azimuthal = Uniform(0,2π) # out-of-plane
 end # struct
 
 Base.@kwdef struct RunReverse <: AbstractMotilityOneStep
     speed = Degenerate(1.0)
-    yaw = Degenerate(π)
-    pitch = Uniform(0,2π)
+    polar = Degenerate(π)
+    azimuthal = Uniform(0,2π)
 end # strut 
 
 Base.@kwdef struct RunReverseFlick <: AbstractMotilityTwoStep
     speed = Degenerate(1.0)
-    yaw_0 = Degenerate(π)
-    pitch_0 = Uniform(0,2π)
-    yaw_1 = Degenerate(π/2)
-    pitch_1 = Uniform(0,2π)
+    polar_0 = Degenerate(π)
+    azimuthal_0 = Uniform(0,2π)
+    polar_1 = Degenerate(π/2)
+    azimuthal_1 = Uniform(0,2π)
     motile_state::Vector{Int} = rand(0:1, 1)
 end # struct 

--- a/src/rotations.jl
+++ b/src/rotations.jl
@@ -28,8 +28,8 @@ function turn!(microbe::AbstractMicrobe, motility::AbstractMotilityOneStep)
     # store actual speed
     U₀ = norm(microbe.vel)
     # perform reorientation
-    θ = rand(motility.yaw)
-    ϕ = rand(motility.pitch)
+    θ = rand(motility.polar)
+    ϕ = rand(motility.azimuthal)
     microbe.vel = rotate(microbe.vel, θ, ϕ) |> Tuple
     # extract new speed from distribution
     U₁ = rand(motility.speed)
@@ -43,11 +43,11 @@ function turn!(microbe::AbstractMicrobe, motility::AbstractMotilityTwoStep)
     U₀ = norm(microbe.vel)
     # perform reorientation depending on current motile state
     if motility.motile_state[1] == 0
-        θ = rand(motility.yaw_0)
-        ϕ = rand(motility.pitch_0)
+        θ = rand(motility.polar_0)
+        ϕ = rand(motility.azimuthal_0)
     else
-        θ = rand(motility.yaw_1)
-        ϕ = rand(motility.pitch_1)
+        θ = rand(motility.polar_1)
+        ϕ = rand(motility.azimuthal_1)
     end # if
     microbe.vel = rotate(microbe.vel, θ, ϕ) |> Tuple
     # update motile state
@@ -65,9 +65,9 @@ function rotational_diffusion!(microbe::AbstractMicrobe, dt)
     D_rot = microbe.rotational_diffusivity
     σ = sqrt(2*D_rot*dt)
     #== this might be wrong ==#
-    yaw = rand(Normal(0, σ))
-    pitch = rand(Uniform(0, 2π))
+    polar = rand(Normal(0, σ))
+    azimuthal = rand(Uniform(0, 2π))
     #==#
-    microbe.vel = Tuple(rotate(microbe.vel, yaw, pitch))
+    microbe.vel = Tuple(rotate(microbe.vel, polar, azimuthal))
     return nothing
 end # function 

--- a/test/reorientations.jl
+++ b/test/reorientations.jl
@@ -42,8 +42,8 @@ using Distributions
 
         vel = rand_vel(2)
         motility = RunReverseFlick(
-            yaw_0 = Degenerate(π),
-            yaw_1 = Degenerate(π/2),
+            polar_0 = Degenerate(π),
+            polar_1 = Degenerate(π/2),
             motile_state = [0]
         )
         m = Microbe{2}(id=1, vel=vel, motility=motility)
@@ -64,10 +64,10 @@ using Distributions
     @testset "Three-dimensional reorientations" begin
         vel = rand_vel(3)
         motility = RunReverseFlick(
-            yaw_0 = Degenerate(π),
-            pitch_0 = Uniform(0,2π),
-            yaw_1 = Degenerate(π/2),
-            pitch_1 = Uniform(0,2π),
+            polar_0 = Degenerate(π),
+            azimuthal_0 = Arccos(-1,1),
+            polar_1 = Degenerate(π/2),
+            azimuthal_1 = Arccos(-1,1),
             motile_state = [0]
         )
         m = Microbe{3}(id=1, vel=vel, motility=motility)


### PR DESCRIPTION
1) Adds the `Arccos` distribution necessary to obtain spherically uniform reorientations in 3D
2) Renames `yaw` and `pitch` fields in motility types to the more accurate `polar` and `azimuthal`

Closes #12