### PR TITLE
Fix random speed generation in type constructors

### DIFF
--- a/src/BacteriaBasedModels.jl
+++ b/src/BacteriaBasedModels.jl
@@ -11,13 +11,13 @@ using Rotations
 using OrdinaryDiffEq: ODEProblem, DEIntegrator, init, Tsit5, step!
 using FiniteDifferences: central_fdm
 
-# Utility routines
-include("utils.jl")
-
 # Core structures
 include("distributions.jl")
 include("motility.jl")
 include("microbes.jl")
+
+# Utility routines
+include("utils.jl")
 
 # ABM setup
 include("model.jl")

--- a/src/brown-berg.jl
+++ b/src/brown-berg.jl
@@ -18,7 +18,7 @@ Base.@kwdef mutable struct MicrobeBrownBerg{D} <: AbstractMicrobe{D}
     id::Int
     pos::NTuple{D,Float64} = ntuple(zero, D)
     motility = RunTumble(speed = Degenerate(30.0))
-    vel::NTuple{D,Float64} = rand_vel(D) .* rand(motility.speed) # μm/s
+    vel::NTuple{D,Float64} = rand_vel(D, motility) # μm/s
     turn_rate::Float64 = 1/0.67 # 1/s
     state::Float64 = 0.0 # 1
     rotational_diffusivity = 0.035 # rad²/s

--- a/src/brumley.jl
+++ b/src/brumley.jl
@@ -21,7 +21,7 @@ Base.@kwdef mutable struct MicrobeBrumley{D} <: AbstractMicrobe{D}
     id::Int
     pos::NTuple{D,Float64} = ntuple(zero, D)
     motility = RunReverseFlick(speed_forward = Degenerate(46.5))
-    vel::NTuple{D,Float64} = rand_vel(D) .* rand(motility.speed_forward)
+    vel::NTuple{D,Float64} = rand_vel(D, motility) # μm/s
     turn_rate::Float64 = 1/0.45 # 1/s
     state::Float64 = 0.0
     rotational_diffusivity::Float64 = 0.035 # rad²/s

--- a/src/celani.jl
+++ b/src/celani.jl
@@ -21,7 +21,7 @@ Base.@kwdef mutable struct Celani{D} <: AbstractCelani{D}
     id::Int
     pos::NTuple{D,Float64} = ntuple(zero, D)
     motility = RunTumble(speed = Degenerate(30.0))
-    vel::NTuple{D,Float64} = rand_vel(D) .* rand(motility.speed) # μm/s
+    vel::NTuple{D,Float64} = rand_vel(D, motility) # μm/s
     turn_rate::Float64 = 1/0.67 # 1/s
     state::Vector{Float64} = [0.,0.,0.,1.] # 1
     rotational_diffusivity = 0.26 # rad²/s
@@ -52,7 +52,7 @@ Base.@kwdef mutable struct CelaniNoisy{D} <: AbstractCelani{D}
     id::Int
     pos::NTuple{D,Float64} = ntuple(zero, D)
     motility = RunTumble(speed = Degenerate(30.0))
-    vel::NTuple{D,Float64} = rand_vel(D) .* rand(motility.speed) # μm/s
+    vel::NTuple{D,Float64} = rand_vel(D, motility) # μm/s
     turn_rate::Float64 = 1/0.67 # 1/s
     state::Vector{Float64} = [0.,0.,0.,1.] # 1
     rotational_diffusivity = 0.26 # rad²/s

--- a/src/microbes.jl
+++ b/src/microbes.jl
@@ -37,7 +37,7 @@ Base.@kwdef mutable struct Microbe{D} <: AbstractMicrobe{D}
     id::Int
     pos::NTuple{D,Float64} = ntuple(zero, D)
     motility = RunTumble()
-    vel::NTuple{D,Float64} = rand_vel(D) .* rand(motility.speed)
+    vel::NTuple{D,Float64} = rand_vel(D, motility)
     turn_rate::Float64 = 1.0
     state::Float64 = 0.0
     rotational_diffusivity::Float64 = 0.0

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,20 +1,46 @@
 export
-    rand_vel, vectorize_adf_measurement
+    rand_vel, rand_speed, vectorize_adf_measurement
 
 """
-    rand_vel(N)
-    rand_vel(rng, N)
+    rand_vel([rng,] N)
 Generate a random N-tuple of unitary norm.
 """
-function rand_vel(D)
-    v = rand(Random.default_rng(), D) .* 2 .- 1
+function rand_vel(D::Int)
+    v = rand(D) .* 2 .- 1
     Tuple(v ./ norm(v))
 end # function
 
-function rand_vel(rng, D)
+function rand_vel(rng, D::Int)
     v = rand(rng, D) .* 2 .- 1
     Tuple(v ./ norm(v))
 end # function
+
+"""
+    rand_speed(m::AbstractMotilityOneStep)
+Extract value from the speed distribution of the motility pattern `m.speed`.
+"""
+rand_speed(m::AbstractMotilityOneStep) = rand(m.speed)
+"""
+    rand_speed(m::AbstractMotilityTwoStep)
+Extract value from the speed distribution of the motility pattern.
+If `motilestate(m) == ForwardState()` extract from `speed_forward`, otherwise
+from `speed_backward`.
+"""
+function rand_speed(m::AbstractMotilityTwoStep)
+    s = motilestate(m)
+    if s == ForwardState()
+        return rand(m.speed_forward)
+    else
+        return rand(m.speed_backward)
+    end
+end
+
+"""
+    rand_vel([rng,] N::Int, m::AbstractMotility)
+Generate a random N-tuple, with norm defined by the speed distribution of `m`.
+"""
+rand_vel(D::Int, m::AbstractMotility) = rand_vel(D) .* rand_speed(m)
+rand_vel(rng, D::Int, m::AbstractMotility) = rand_vel(rng, D) .* rand_speed(m)
 
 """
     vectorize_adf_measurement(adf, sym)

--- a/src/xie.jl
+++ b/src/xie.jl
@@ -6,7 +6,7 @@ Base.@kwdef mutable struct Xie{D} <: AbstractXie{D}
     id::Int
     pos::NTuple{D,Float64} = ntuple(zero, D)
     motility = RunReverse(speed_forward = Degenerate(46.5))
-    vel::NTuple{D,Float64} = rand_vel(D) .* randspeed(motility)
+    vel::NTuple{D,Float64} = rand_vel(D, motility)
     turn_rate_forward::Float64 = 2.3 # 1/s
     turn_rate_backward::Float64 = 1.9 # 1/s
     state_m::Float64 = 0.0 # s
@@ -25,7 +25,7 @@ Base.@kwdef mutable struct XieNoisy{D} <: AbstractXie{D}
     id::Int
     pos::NTuple{D,Float64} = ntuple(zero, D)
     motility = RunReverse(speed_forward = Degenerate(46.5))
-    vel::NTuple{D,Float64} = rand_vel(D) .* randspeed(motility)
+    vel::NTuple{D,Float64} = rand_vel(D, motility)
     turn_rate_forward::Float64 = 2.3 # 1/s
     turn_rate_backward::Float64 = 1.9 # 1/s
     state_m::Float64 = 0.0 # s
@@ -40,9 +40,6 @@ Base.@kwdef mutable struct XieNoisy{D} <: AbstractXie{D}
     rotational_diffusivity::Float64 = 0.26 # rad²/s
     radius::Float64 = 0.5 # μm
 end
-
-randspeed(m::AbstractMotilityTwoStep) = m.motile_state == ForwardState ? rand(m.speed_forward) : rand(m.speed_backward)
-
 
 function xie_affect!(microbe::Xie, model)
     Δt = model.timestep

--- a/test/microbe_creation.jl
+++ b/test/microbe_creation.jl
@@ -26,6 +26,11 @@ using LinearAlgebra: norm
         @test m.rotational_diffusivity == 0.0
         @test m.radius == 0.0
 
+        # test constructor works for all types of motility
+        @test_nowarn Microbe{2}(id=0, motility=RunTumble())
+        @test_nowarn Microbe{2}(id=0, motility=RunReverse())
+        @test_nowarn Microbe{2}(id=0, motility=RunReverseFlick())
+
         # test some arguments again for 3D
         id = rand(Int)
         D = 3


### PR DESCRIPTION
- Defines a new `rand_speed(motility)` function to extract speed from motility types
- Extends `rand_vel` to generate a velocity vector with speed defined by the distribution in the motility type
- Fixes bugs in type constructors

Closes #33